### PR TITLE
remove need to explicitly close socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,7 @@ logger.log("What we've got here is...failure to communicate", "Some men you just
 );
 ```
 
-Flush all log messages and close down:
-```javascript
-logger.close(function(){
-    console.log('All done - cookie now?');
-    process.exit();
-});
-```
+The connection will be closed automatically at the end of your program.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,3 @@ It's a miracle. Get it at http://www.graylog2.org/
 ## Installation
 
     npm install graylog2
-
-## Original author
-
-Egor Egorov <me@egorfine.com>

--- a/README.md
+++ b/README.md
@@ -98,11 +98,6 @@ It's a miracle. Get it at http://www.graylog2.org/
 
     npm install graylog2
 
-## License
-
-See LICENSE file. Basically, it's a kind of "do-whatever-you-want-for-free" license.
-
 ## Original author
 
 Egor Egorov <me@egorfine.com>
-

--- a/graylog.js
+++ b/graylog.js
@@ -1,7 +1,7 @@
-var zlib         = require('zlib'),
-    crypto       = require('crypto'),
-    dgram        = require('dgram'),
-    util         = require('util'),
+var zlib = require('zlib'),
+    crypto = require('crypto'),
+    dgram = require('dgram'),
+    util = require('util'),
     EventEmitter = require('events').EventEmitter;
 
 /**
@@ -12,21 +12,21 @@ var zlib         = require('zlib'),
 var graylog = function graylog(config) {
     EventEmitter.call(this);
 
-    this.config       = config;
+    this.config = config;
 
-    this.servers      = config.servers;
-    this.client       = null;
-    this.hostname     = config.hostname || require('os').hostname();
-    this.facility     = config.facility || 'Node.js';
+    this.servers = config.servers;
+    this.client = null;
+    this.hostname = config.hostname || require('os').hostname();
+    this.facility = config.facility || 'Node.js';
 
     this._unsentMessages = 0;
     this._unsentChunks = 0;
-    this._callCount   = 0;
+    this._callCount = 0;
 
     this._onClose = null;
     this._isDestroyed = false;
 
-    this._bufferSize  = config.bufferSize || this.DEFAULT_BUFFERSIZE;
+    this._bufferSize = config.bufferSize || this.DEFAULT_BUFFERSIZE;
 };
 
 util.inherits(graylog, EventEmitter);
@@ -34,15 +34,15 @@ util.inherits(graylog, EventEmitter);
 graylog.prototype.DEFAULT_BUFFERSIZE = 1400;  // a bit less than a typical MTU of 1500 to be on the safe side
 
 graylog.prototype.level = {
-    EMERG: 0,    // system is unusable
-    ALERT: 1,    // action must be taken immediately
-    CRIT: 2,     // critical conditions
-    ERR: 3,      // error conditions
-    ERROR: 3,    // because people WILL typo
-    WARNING: 4,  // warning conditions
-    NOTICE: 5,   // normal, but significant, condition
-    INFO: 6,     // informational message
-    DEBUG: 7     // debug level message
+    EMERG: 0, // system is unusable
+    ALERT: 1, // action must be taken immediately
+    CRIT: 2, // critical conditions
+    ERR: 3, // error conditions
+    ERROR: 3, // because people WILL typo
+    WARNING: 4, // warning conditions
+    NOTICE: 5, // normal, but significant, condition
+    INFO: 6, // informational message
+    DEBUG: 7 // debug level message
 };
 
 graylog.prototype.getServer = function () {
@@ -111,31 +111,31 @@ graylog.prototype._log = function log(short_message, full_message, additionalFie
 
     var payload,
         fileinfo,
-        that    = this,
-        field   = '',
+        that = this,
+        field = '',
         message = {
-            version    : '1.0',
-            timestamp  : (timestamp || new Date()).getTime() / 1000,
-            host       : this.hostname,
-            facility   : this.facility,
-            level      : level
+            version : '1.0',
+            timestamp : (timestamp || new Date()).getTime() / 1000,
+            host : this.hostname,
+            facility : this.facility,
+            level : level
         };
 
     if (typeof(short_message) !== 'object' && typeof(full_message) === 'object' && additionalFields === undefined) {
         // Only short message and additional fields are available
-        message.short_message   = short_message;
-        message.full_message    = short_message;
+        message.short_message = short_message;
+        message.full_message = short_message;
 
         additionalFields = full_message;
-    } else  if (typeof(short_message) !== 'object') {
+    } else if (typeof(short_message) !== 'object') {
         // We normally set the data
-        message.short_message   = short_message;
-        message.full_message    = full_message || short_message;
+        message.short_message = short_message;
+        message.full_message = full_message || short_message;
     } else if (short_message.stack && short_message.message) {
 
         // Short message is an Error message, we process accordingly
         message.short_message = short_message.message;
-        message.full_message  = short_message.stack;
+        message.full_message = short_message.stack;
 
         // extract error file and line
         fileinfo = message.stack.split('\n')[0];
@@ -179,7 +179,7 @@ graylog.prototype._log = function log(short_message, full_message, additionalFie
         // It didn't fit, so prepare for a chunked stream
 
         var bufferSize = that._bufferSize;
-        var dataSize   = bufferSize - 12;  // the data part of the buffer is the buffer size - header size
+        var dataSize = bufferSize - 12;  // the data part of the buffer is the buffer size - header size
         var chunkCount = Math.ceil(buffer.length / dataSize);
 
         if (chunkCount > 128) {
@@ -223,7 +223,7 @@ graylog.prototype._log = function log(short_message, full_message, additionalFie
 
                 // Copy data from full buffer into the chunk
                 var start = chunkSequenceNumber * dataSize;
-                var stop  = Math.min((chunkSequenceNumber + 1) * dataSize, buffer.length);
+                var stop = Math.min((chunkSequenceNumber + 1) * dataSize, buffer.length);
 
                 buffer.copy(chunk, 12, start, stop);
 

--- a/graylog.js
+++ b/graylog.js
@@ -291,8 +291,6 @@ graylog.prototype.close = function (cb) {
         });
     }
 
-    var that = this;
-
     this._onClose = function () {
         that.destroy();
 

--- a/graylog.js
+++ b/graylog.js
@@ -251,7 +251,7 @@ graylog.prototype.send = function (chunk, server, cb) {
 
     this._unsentChunks += 1;
 
-    client.send(chunk, 0, chunk.length, server.port, server.host, function (err/*, bytes */) {
+    client.send(chunk, 0, chunk.length, server.port, server.host, function (err) {
         that._unsentChunks -= 1;
 
         if (err) {

--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-    "name": "graylog2",
-    "description": "Graylog2 client library for node.js",
-    "homepage": "http://github.com/Wizcorp/node-graylog2",
-    "bugs": {
-        "url": "http://github.com/Wizcorp/node-graylog2/issues"
-    },
-    "version": "0.1.3",
-    "author": "Marc Trudel-Belise",
-    "engines": {
-        "node": ">=0.6.11"
-    },
-    "devDependencies": {
-        "jshint": "0.9.1"
-    },
-    "repository": {
-        "type": "git",
-        "url": "http://github.com/Wizcorp/node-graylog2.git"
-    },
-    "scripts": {
-        "test": "node ./test"
-    },
-    "main": "./graylog.js"
+  "name": "graylog2",
+  "description": "Graylog2 client library for node.js",
+  "version": "0.1.3",
+  "author": "Marc Trudel-Belise",
+  "bugs": {
+    "url": "http://github.com/Wizcorp/node-graylog2/issues"
+  },
+  "devDependencies": {
+    "jshint": "0.9.1"
+  },
+  "engines": {
+    "node": ">=0.6.11"
+  },
+  "homepage": "http://github.com/Wizcorp/node-graylog2",
+  "main": "./graylog.js",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/Wizcorp/node-graylog2.git"
+  },
+  "scripts": {
+    "test": "node ./test"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node": ">=0.6.11"
   },
   "homepage": "http://github.com/Wizcorp/node-graylog2",
+  "license": "MIT",
   "main": "./graylog.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "bugs": {
     "url": "http://github.com/Wizcorp/node-graylog2/issues"
   },
+  "contributors": [
+    {
+      "name": "Egor Egorov",
+      "email": "me@egorfine.com"
+    }
+  ],
   "devDependencies": {
     "jshint": "0.9.1"
   },

--- a/test.js
+++ b/test.js
@@ -49,7 +49,6 @@ client.log('ParametersTest - Short message and full message', 'Full message');
 client.log('ParametersTest - Short Message with full message and json', 'Full message', {cool: 'beans'});
 console.log('');
 
-client.close(function () {
-    console.log('Insertion complete. Please check', 'http://' + servers[0].host + ':3000', 'and verify that insertion was successfull');
-    console.log('');
-});
+
+console.log('Insertion complete. Please check', 'http://' + servers[0].host + ':3000', 'and verify that insertion was successfull');
+console.log('');

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 var graylog = require('./graylog'),
-    fs      = require('fs'),
+    fs = require('fs'),
     file,
     data,
     servers = [


### PR DESCRIPTION
Since we aren't listening for messages, there's no need to keep it open once the rest of the script is done, and there isn't any need to close it early because UDP doesn't maintain any sort of a connection.

This is based on #8 (which should be merged first), and this requires a major version bump.

The intention is to fix https://github.com/namshi/winston-graylog2/issues/24