### PR TITLE
fix: typo fixed in fileinfo stack message

### DIFF
--- a/graylog.js
+++ b/graylog.js
@@ -143,7 +143,7 @@ graylog.prototype._log = function log(short_message, full_message, additionalFie
         message.full_message  = short_message.stack;
 
         // extract error file and line
-        fileinfo = message.stack.split('\n')[0];
+        fileinfo = short_message.stack.split('\n')[0];
         fileinfo = fileinfo.substr(fileinfo.indexOf('('), fileinfo.indexOf(')'));
         fileinfo = fileinfo.split(':');
 


### PR DESCRIPTION
TypeError: Cannot read property 'split' of undefined at graylog.log [as _log] (/home/node/app/node_modules/graylog2/graylog.js:146:34)

If it was just a typo, this PR should fix that.

But it's useful to check Wizcorp#23, too!